### PR TITLE
Change embed description of /notabot to not mention the serious channel anymore. As per Nova's request :3

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -74,10 +74,9 @@ class Utility(commands.Cog):
         embed.set_footer(icon_url=ctx.author.avatar.url, text=f"Summoned by {ctx.author.display_name}")
 
         embed.description = "This server has a system that allows people to communicate though a proxy.\nThis " \
-                            "benefits people who experience [plurality](https://morethanone.info/). In the serious " \
-                            "category channels, they can be used for anonymity.\n\nDue to the way this system works, " \
-                            "some messages may show up with a [BOT] however these messages are still sent by normal " \
-                            "people and thus should be treated as such."
+                            "benefits people who experience [plurality](https://morethanone.info/) .\n\nDue to the "\
+                            "way this system works, some messages may show up with a [BOT] however these messages " \
+                            "are still sent by normal people and thus should be treated as such."
 
         await ctx.respond(embed=embed)
 


### PR DESCRIPTION
So uh I was kinda bored and we used /notabot today and someone mentioned how we should change it. Today's a slow day so I thought fuck it let's send a PR :3
<img width="1229" alt="Screenshot 2024-11-06 at 21 44 04" src="https://github.com/user-attachments/assets/bb6856f6-8f1e-4129-9817-da7ccac1b38a">
